### PR TITLE
Fix | getReviewWeight function |

### DIFF
--- a/server/_util.js
+++ b/server/_util.js
@@ -38,9 +38,15 @@ function getAverageTravelledWith(reviews) {
 }
 
 function getReviewWeight(review) {
-  // TODO: return the right calculations here instead of 1
-  // according to the provided info in README.md file
-  return 1;
+  const currentYear = new Date().getFullYear();
+  const reviewYear = new Date(review.date).getFullYear();
+  const yearsSinceReview = currentYear - reviewYear;
+
+  if (yearsSinceReview > 5) {
+    return 0.5;
+  } else {
+    return 1 - (yearsSinceReview * 0.1);
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Instead of returning 1, the function is now returning the correct value according to the requirement provided in the README.md file